### PR TITLE
fix: Use the PageHandler's mapper to orchestrate edge-to-edge logic #1

### DIFF
--- a/NUGET-README.md
+++ b/NUGET-README.md
@@ -129,6 +129,33 @@ The previous example can be simplified with the following for example:
     </Grid>
 </ContentPage>
 ```
+## Issues
+
+On iOS, there is en open issue with the `IgnoreSafeArea` propety of .NET MAUI's Layout views. This means that even with the edge-to-edge enabled, layouts inside the safe area will get a padding added (not a .NET MAUI padding, the bounds calculation at the iOS level is overriden). Unfortunately, there is no easy workaround that can be implemented in this library.
+
+To help with this issue, the `bool` property `CancelIOSPadding` has been added. Set the property to true for all the layouts that are parents of your inset padding:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:insets="https://schemas.the49.com/dotnet/2023/maui"
+             x:Class="The49.Maui.Insets.Sample.SalmonPage"
+             insets:Insets.EdgeToEdge="True"
+             Shell.NavBarIsVisible="False"
+             Title="SalmonPage">
+    <Grid RowDefinitions="Auto, Auto, *, Auto, Auto" insets:Insets.CancelIOSPadding="True">
+        <insets:TopInsetView Background="Salmon">
+            <Label Text="Main Page" Padding="16" FontSize="22" TextColor="White" HorizontalOptions="Center" />
+        </insets:TopInsetView>
+        <Label Text="^^^ This view is padded to avoid colliding with the status bar ^^^" FontSize="12" HorizontalTextAlignment="Center" Grid.Row="1" />
+        <Label Text="vvv This view is padded to avoid colliding with navigation bar vvv" FontSize="12" HorizontalTextAlignment="Center" Grid.Row="3" />
+        <insets:BottomInsetView Background="Salmon" Grid.Row="4">
+            <Label Text="Footer" FontSize="22" TextColor="White" HorizontalOptions="Center" />
+        </insets:BottomInsetView>
+    </Grid>
+</ContentPage>
+```
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -139,6 +139,34 @@ The previous example can be simplified with the following for example:
 ```
 
 
+## Issues
+
+On iOS, there is en open issue with the `IgnoreSafeArea` propety of .NET MAUI's Layout views. This means that even with the edge-to-edge enabled, layouts inside the safe area will get a padding added (not a .NET MAUI padding, the bounds calculation at the iOS level is overriden). Unfortunately, there is no easy workaround that can be implemented in this library.
+
+To help with this issue, the `bool` property `CancelIOSPadding` has been added. Set the property to true for all the layouts that are parents of your inset padding:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:insets="https://schemas.the49.com/dotnet/2023/maui"
+             x:Class="The49.Maui.Insets.Sample.SalmonPage"
+             insets:Insets.EdgeToEdge="True"
+             Shell.NavBarIsVisible="False"
+             Title="SalmonPage">
+    <Grid RowDefinitions="Auto, Auto, *, Auto, Auto" insets:Insets.CancelIOSPadding="True">
+        <insets:TopInsetView Background="Salmon">
+            <Label Text="Main Page" Padding="16" FontSize="22" TextColor="White" HorizontalOptions="Center" />
+        </insets:TopInsetView>
+        <Label Text="^^^ This view is padded to avoid colliding with the status bar ^^^" FontSize="12" HorizontalTextAlignment="Center" Grid.Row="1" />
+        <Label Text="vvv This view is padded to avoid colliding with navigation bar vvv" FontSize="12" HorizontalTextAlignment="Center" Grid.Row="3" />
+        <insets:BottomInsetView Background="Salmon" Grid.Row="4">
+            <Label Text="Footer" FontSize="22" TextColor="White" HorizontalOptions="Center" />
+        </insets:BottomInsetView>
+    </Grid>
+</ContentPage>
+```
+
 ---
 
 

--- a/The49.Maui.Insets.Sample/MainPage.xaml
+++ b/The49.Maui.Insets.Sample/MainPage.xaml
@@ -8,8 +8,8 @@
              insets:Insets.EdgeToEdge="{Binding ShouldUseEdgeToEdge, Source={x:Reference this}}"
              insets:Insets.StatusBarStyle="{Binding StatusBarStyle, Source={x:Reference this}}"
              Title="FullWindowPage">
-    <Grid RowDefinitions="Auto, *">
-        <AbsoluteLayout>
+    <Grid RowDefinitions="Auto, *" insets:Insets.CancelIOSPadding="True">
+        <AbsoluteLayout insets:Insets.CancelIOSPadding="True">
             <Image Source="curry.jpg" Aspect="AspectFill" AbsoluteLayout.LayoutBounds="0,0, 1, 1" AbsoluteLayout.LayoutFlags="SizeProportional" />
             <insets:TopInsetView BackgroundColor="#77000000" HorizontalOptions="FillAndExpand" AbsoluteLayout.LayoutBounds="0,0, 1, -1" AbsoluteLayout.LayoutFlags="WidthProportional">
                 <ContentView HeightRequest="120">

--- a/The49.Maui.Insets.Sample/SalmonPage.xaml
+++ b/The49.Maui.Insets.Sample/SalmonPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:insets="https://schemas.the49.com/dotnet/2023/maui"
@@ -6,7 +6,7 @@
              insets:Insets.EdgeToEdge="True"
              Shell.NavBarIsVisible="False"
              Title="SalmonPage">
-    <Grid RowDefinitions="Auto, Auto, *, Auto, Auto">
+    <Grid RowDefinitions="Auto, Auto, *, Auto, Auto" insets:Insets.CancelIOSPadding="True">
         <insets:TopInsetView Background="Salmon">
             <Label Text="Main Page" Padding="16" FontSize="22" TextColor="White" HorizontalOptions="Center" />
         </insets:TopInsetView>

--- a/The49.Maui.Insets/Platforms/iOS/Insets.cs
+++ b/The49.Maui.Insets/Platforms/iOS/Insets.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using Foundation;
+using Microsoft.Maui.Handlers;
 using UIKit;
 
 namespace The49.Maui.Insets;
@@ -18,8 +19,19 @@ public partial class Insets
     }
     static partial void PlatformInit(Page page)
     {
-        var insets = UIApplication.SharedApplication.KeyWindow.SafeAreaInsets;
+        var insets = UIApplication.SharedApplication.GetSafeAreaInsetsForWindow();
         Current.SetInsets(new Thickness(insets.Left, insets.Top, insets.Right, insets.Bottom));
+    }
+    static partial void UpdateIOSPadding(Layout layout)
+    {
+        if (GetCancelIOSPadding(layout))
+        {
+            layout.SetBinding(Layout.PaddingProperty, new Binding(nameof(NegativeInsetsThickness), source: Current));
+        }
+        else
+        {
+            layout.RemoveBinding(Layout.PaddingProperty);
+        }
     }
     static partial void UpdateEdgeToEdge(Page page)
     {
@@ -28,13 +40,11 @@ public partial class Insets
         if (edgeToEdge)
         {
             Current.SetEnabled(true);
-            Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(page, false);
             page.SetBinding(Page.PaddingProperty, new Binding(nameof(NegativeInsetsThickness), source: Current));
         }
         else
         {
             Current.SetEnabled(false);
-            Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(page, true);
             page.RemoveBinding(Page.PaddingProperty);
         }
     }

--- a/The49.Maui.Insets/Platforms/iOS/UIApplicationExtensions.cs
+++ b/The49.Maui.Insets/Platforms/iOS/UIApplicationExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using UIKit;
+
+namespace The49.Maui.Insets;
+
+internal static class UIApplicationExtensions
+{
+    internal static UIEdgeInsets GetSafeAreaInsetsForWindow(this UIApplication application)
+    {
+        UIEdgeInsets safeAreaInsets;
+
+        if (!OperatingSystem.IsIOSVersionAtLeast(11))
+            safeAreaInsets = new UIEdgeInsets(UIApplication.SharedApplication.StatusBarFrame.Size.Height, 0, 0, 0);
+#pragma warning disable CA1422 // Validate platform compatibility
+        else if (application.GetKeyWindow() is UIWindow keyWindow)
+            safeAreaInsets = keyWindow.SafeAreaInsets;
+#pragma warning disable CA1416 // TODO: 'UIApplication.Windows' is unsupported on: 'ios' 15.0 and later.
+        else if (application.Windows.Length > 0)
+            safeAreaInsets = application.Windows[0].SafeAreaInsets;
+#pragma warning restore CA1416
+        else
+            safeAreaInsets = UIEdgeInsets.Zero;
+#pragma warning restore CA1422 // Validate platform compatibility
+
+        return safeAreaInsets;
+    }
+
+    public static UIWindow? GetKeyWindow(this UIApplication application)
+    {
+#pragma warning disable CA1416 // TODO: 'UIApplication.Windows' is unsupported on: 'ios' 15.0 and later.
+#pragma warning disable CA1422 // Validate platform compatibility
+        var windows = application.Windows;
+#pragma warning restore CA1422 // Validate platform compatibility
+#pragma warning restore CA1416
+
+        for (int i = 0; i < windows.Length; i++)
+        {
+            var window = windows[i];
+            if (window.IsKeyWindow)
+                return window;
+        }
+
+        return null;
+    }
+
+    public static IWindow? GetWindow(this UIApplication application) =>
+        application.GetKeyWindow().GetWindow();
+
+    public static IWindow? GetWindow(this UIWindow? platformWindow)
+    {
+        if (platformWindow is null)
+            return null;
+
+        foreach (var window in MauiUIApplicationDelegate.Current.Application.Windows)
+        {
+            if (window?.Handler?.PlatformView == platformWindow)
+                return window;
+        }
+
+        return null;
+    }
+
+    public static IWindow? GetWindow(this UIWindowScene? windowScene)
+    {
+        if (windowScene is null)
+            return null;
+
+#pragma warning disable CA1416 // TODO: 'UIApplication.Windows' is unsupported on: 'ios' 15.0 and later
+        foreach (var window in windowScene.Windows)
+        {
+            var managedWindow = window.GetWindow();
+
+            if (managedWindow is not null)
+                return managedWindow;
+        }
+#pragma warning restore CA1416
+
+        if (!OperatingSystem.IsIOSVersionAtLeast(13))
+            return null;
+        else if (windowScene.Delegate is IUIWindowSceneDelegate sd)
+            return sd.GetWindow().GetWindow();
+
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #1 by using the PageHandler instead of hooking into the AppShell and NavigationPage events.

This also makes transitions on iOS look better when goind from a page with edge-to-edge enabled as the shift happens before the animation